### PR TITLE
docs: Updates reselect comparison and adds hook examples

### DIFF
--- a/docs/react-redux/useProxySelector.md
+++ b/docs/react-redux/useProxySelector.md
@@ -1,0 +1,40 @@
+# useProxySelector Hook
+This creates a `useProxySelector` hook which can be used to create a typed `useSelector` hook powered by `proxy-memoize`. By defining this hook in your application code, you can ensure that the `state` object reflects your redux state object.
+
+## The Hook
+```ts
+import memoize from "proxy-memoize";
+import { useCallback } from "react";
+import { useSelector } from "react-redux";
+
+// import your react-redux RootState type
+import type { RootState } from "./path/to/root/state/declaration";
+
+const createProxySelectorHook = <TState extends object = any>() => {
+  const useProxySelector = <TReturnType>(
+    fn: (state: TState) => TReturnType,
+    deps?: any[]
+  ): TReturnType => {
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return useSelector(useCallback(memoize(fn), deps));
+  };
+  return useProxySelector;
+};
+
+// export
+export const useProxySelector = createProxySelectorHook<RootState>();
+```
+
+## Usage in Code
+```tsx
+interface Props {
+  value: string;
+}
+
+const MyComponent:React.FC<Props> = ({ value }) => {
+  const result = useProxySelector((state) => {
+    return `${value}-modified`
+  }, [value]);
+  return (<div>{result}</div>);
+}
+```


### PR DESCRIPTION
Fixes #29

In updating the reselect comparison docs, we provide a clear comparison of the two main use cases where `proxy-memoize` would be a strong alternative to reselect's `createSelector` interface. Additionally, this commit includes an `examples/` directory, providing a place for us to put other code samples or recipes that do not expand on the API surface area of `proxy-memoize`. This examples directory was seeded with the first example of `useProxySelector` as an example typed hook that mirrors the functionality of redux toolkit's `createAppSelector` pattern.