### PR TITLE
feat: Use CircularQueue replace Array

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,8 @@
     "symbol-description": "off",
     "@typescript-eslint/ban-types": "off",
     "no-param-reassign": "off",
+    "no-underscore-dangle": "off",
+    "import/prefer-default-export": "off",
     "no-unused-vars": "off"
   },
   "overrides": [{

--- a/__tests__/queue_spec.ts
+++ b/__tests__/queue_spec.ts
@@ -1,0 +1,48 @@
+import { CircularQueue } from '../src/queue';
+
+describe('basic spec', () => {
+  it('enqueue and dequeue', () => {
+    const q = new CircularQueue(3);
+    expect(q.empty()).toEqual(true);
+    expect(q.full()).toEqual(false);
+    expect(q.size()).toEqual(0);
+    q.enqueue(0);
+    expect(q.empty()).toEqual(false);
+    expect(q.full()).toEqual(false);
+    expect(q.size()).toEqual(1);
+    q.enqueue(1);
+    q.enqueue(2);
+    expect(q.empty()).toEqual(false);
+    expect(q.full()).toEqual(true);
+    expect(q.size()).toEqual(3);
+    q.enqueue(3);
+    q.enqueue(4);
+    expect(q.empty()).toEqual(false);
+    expect(q.full()).toEqual(true);
+    expect(q.size()).toEqual(3);
+    q.dequeue();
+    q.dequeue();
+    q.dequeue();
+    q.dequeue();
+    expect(q.empty()).toEqual(true);
+    expect(q.full()).toEqual(false);
+    expect(q.size()).toEqual(0);
+  });
+
+  it('get item', () => {
+    const q = new CircularQueue(3);
+    q.enqueue(0);
+    q.enqueue(1);
+    q.enqueue(2);
+    const list1 = [0, 1, 2];
+    for (let i = 0; i < q.size(); i += 1) {
+      expect(q.get(i)).toEqual(list1[i]);
+    }
+    q.enqueue(3);
+    q.enqueue(4);
+    const list2 = [2, 3, 4];
+    for (let i = 0; i < q.size(); i += 1) {
+      expect(q.get(i)).toEqual(list2[i]);
+    }
+  });
+});

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -31,9 +31,10 @@ export class CircularQueue<T> {
     return true;
   }
 
-  private dequeue() {
-    // We only use the enqueue method, so dequeue don't need to check empty
-    // if(this.empty()) return false;
+  dequeue() {
+    if (this.empty()) {
+      return false;
+    }
     this._head = (this._head + 1) % this._size;
     this._data[this._head] = undefined as unknown as T;
     return true;

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,0 +1,49 @@
+export class CircularQueue<T> {
+  _data: T[];
+
+  _size: number;
+
+  _tail: number;
+
+  _head: number;
+
+  constructor(size: number) {
+    this._data = Array(size + 1);
+    this._size = size + 1;
+    this._tail = 1;
+    this._head = 0;
+  }
+
+  get(i: number) {
+    return this._data[(this._head + i + 1) % this._size];
+  }
+
+  size() {
+    return (this._tail - this._head + this._size - 1) % this._size;
+  }
+
+  enqueue(val: T) {
+    if (this.full()) {
+      this.dequeue();
+    }
+    this._data[this._tail] = val;
+    this._tail = (this._tail + 1) % this._size;
+    return true;
+  }
+
+  private dequeue() {
+    // We only use the enqueue method, so dequeue don't need to check empty
+    // if(this.empty()) return false;
+    this._head = (this._head + 1) % this._size;
+    this._data[this._head] = undefined as unknown as T;
+    return true;
+  }
+
+  empty() {
+    return (this._head + 1) % this._size === this._tail;
+  }
+
+  full() {
+    return this._head === this._tail;
+  }
+}


### PR DESCRIPTION
CircularQueue are much faster than arrays, even if the length of the array is small (eg: 1,2)

```
event: Array#1 x 291,168 ops/sec ±0.29% (94 runs sampled)
event: Circular#1 x 2,745,702 ops/sec ±0.66% (92 runs sampled)
event: Array#16 x 2,701 ops/sec ±0.26% (97 runs sampled)
event: Circular#16 x 13,064 ops/sec ±0.77% (95 runs sampled)
event: Array#2 x 295,289 ops/sec ±0.25% (95 runs sampled)
event: Circular#2 x 1,248,051 ops/sec ±1.06% (96 runs sampled)
event: Array#32 x 2,654 ops/sec ±0.48% (96 runs sampled)
event: Circular#32 x 13,160 ops/sec ±0.18% (98 runs sampled)
event: Array#4 x 269,338 ops/sec ±0.26% (95 runs sampled)
event: Circular#4 x 1,264,973 ops/sec ±0.25% (96 runs sampled)
event: Array#64 x 2,440 ops/sec ±0.54% (97 runs sampled)
event: Circular#64 x 13,031 ops/sec ±0.69% (97 runs sampled)
event: Array#8 x 262,999 ops/sec ±0.27% (96 runs sampled)
event: Circular#8 x 1,275,477 ops/sec ±0.26% (93 runs sampled)
event: Array#128 x 2,241 ops/sec ±0.21% (95 runs sampled)
event: Circular#128 x 13,078 ops/sec ±0.35% (98 runs sampled)
```