### PR TITLE
refactor with array based queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- refactor with array based queue #41
 
 ## [1.0.0] - 2022-04-13
 ### Added


### PR DESCRIPTION
@ahaoboy Is this something you wanted in #40?

```
wc dist*/index.*.js                             
       2      38     936 dist-5068948/index.modern.js
       2      31    1253 dist-5068948/index.umd.js
       2      39     941 dist-e911e1b/index.modern.js
       2      31    1252 dist-e911e1b/index.umd.js
       8     139    4382 total
```
5 byte increase for modern, and 1 byte reduction for umd. Not bad.