### PR TITLE
fix: use target cache for better performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "proxy-compare": "2.4.0"
+    "proxy-compare": "2.5.1"
   },
   "devDependencies": {
     "@types/jest": "^29.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 dependencies:
   proxy-compare:
-    specifier: 2.4.0
-    version: 2.4.0
+    specifier: 2.5.1
+    version: 2.5.1
 
 devDependencies:
   '@types/jest':
@@ -6468,8 +6468,8 @@ packages:
     resolution: {integrity: sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==}
     dev: true
 
-  /proxy-compare@2.4.0:
-    resolution: {integrity: sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg==}
+  /proxy-compare@2.5.1:
+    resolution: {integrity: sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA==}
     dev: false
 
   /punycode@2.3.0:

--- a/src/memoize.ts
+++ b/src/memoize.ts
@@ -5,6 +5,10 @@ import {
   trackMemo,
 } from 'proxy-compare';
 
+// This is required only for performance.
+// https://github.com/dai-shi/proxy-memoize/issues/68
+const targetCache = new WeakMap();
+
 // constants from proxy-compare
 const HAS_KEY_PROPERTY = 'h';
 const ALL_OWN_KEYS_PROPERTY = 'w';
@@ -108,7 +112,7 @@ export function memoize<Obj extends object, Result>(
       }
     }
     const affected: Affected = new WeakMap();
-    const proxy = createProxy(obj, affected);
+    const proxy = createProxy(obj, affected, undefined, targetCache);
     const result = untrack(fn(proxy), new Set());
     touchAffected(obj, obj, affected);
     const entry: Entry = {


### PR DESCRIPTION

proxy-memoize@^2.0.3:
![image](https://user-images.githubusercontent.com/37929992/236252801-a44b2eee-f1d0-4093-8247-a29b525ad868.png)

proxy-memoize@https://pkg.csb.dev/dai-shi/proxy-memoize/commit/7c27c228/proxy-memoize:
![image](https://user-images.githubusercontent.com/37929992/236253008-8b13c920-0a3c-47e8-9141-92fb02c7f920.png)
